### PR TITLE
rpsls development April 2020

### DIFF
--- a/rock-paper-scissors-lizard-spock/README.md
+++ b/rock-paper-scissors-lizard-spock/README.md
@@ -20,8 +20,8 @@ If no set of players is defined the program will choose randomly two players for
 
 A set of players can be assigned in a file `rpsls.txt` which should be located in the same directory. The format of the file is simple text with two players (one round) on each line, for example:
 ```
-player1, player2
-player1, player2
+player1 player2
+player1 player2
 ...
 ```
 

--- a/rock-paper-scissors-lizard-spock/README.md
+++ b/rock-paper-scissors-lizard-spock/README.md
@@ -12,6 +12,22 @@
 - lizard: poisons Spock, eats paper
 - Spock: smashes scissors, vaporises rock
 
+## Usage
+
+The program reads an environment variable (`RPSLS_ROUNDS`) to determine how many rounds to run.
+
+If no set of players is defined the program will choose randomly two players for each round.
+
+A set of players can be assigned in a file `rpsls.txt` which should be located in the same directory. The format of the file is simple text with two players (one round) on each line, for example:
+```
+player1, player2
+player1, player2
+...
+```
+
+If `number players < number of rounds` the program will cycle through the list and restart from the beginning until the number of rounds is completed. If `number of players > number of rounds` the program will stop once the number of rounds is completed ignoring the rest of the players lines.
+
+
 ## Testing
 
 Set the ENV variables needed in `pytest.ini`.

--- a/rock-paper-scissors-lizard-spock/rpsls.py
+++ b/rock-paper-scissors-lizard-spock/rpsls.py
@@ -2,6 +2,7 @@
 
 import os
 from random import choice
+from itertools import cycle
 
 ROUNDS: int = int(os.environ.get("RPSLS_ROUNDS", 10))
 PLAYERS_FILE: str = "rpsls.txt"
@@ -37,10 +38,22 @@ def load_players_file() -> list:
     # of empty players
     if not os.path.isfile(PLAYERS_FILE):
         return [("", "")] * ROUNDS
-    # read the file, parse it and perform sanity check
+    # read the file, parse the data and perform some
+    # basic sanity check
     with open(PLAYERS_FILE) as f:
         data = f.readlines()
-    return data
+    _players = []
+    for line in data:
+        parsed = line.strip().split()
+        if len(parsed) != 2:
+            continue
+        elif all(p in players_list for p in parsed):
+            p_one, p_two = parsed
+            _players.append((p_one, p_two))
+    # create a cycle generator
+    cycle_players = cycle(_players)
+    # return n tuples of players with n equals to ROUNDS
+    return [next(cycle_players) for counter in range(ROUNDS)]
 
 
 def match(one: str = "", two: str = "") -> str:

--- a/rock-paper-scissors-lizard-spock/rpsls.py
+++ b/rock-paper-scissors-lizard-spock/rpsls.py
@@ -42,6 +42,11 @@ def match(one: str = "", two: str = "") -> str:
 def main() -> None:
     print("Rock, paper, scissors, lizard, Spock")
     print(f"Will play {ROUNDS} rounds")
+    counter = 0
+    while counter < ROUNDS:
+        winner = match()
+        print(winner)
+        counter += 1
 
 
 if __name__ == "__main__":

--- a/rock-paper-scissors-lizard-spock/rpsls.py
+++ b/rock-paper-scissors-lizard-spock/rpsls.py
@@ -4,6 +4,7 @@ import os
 from random import choice
 
 ROUNDS: int = int(os.environ.get("RPSLS_ROUNDS", 10))
+PLAYERS_FILE: str = "rpsls.txt"
 players_list: list = ["rock", "paper", "scissors", "lizard", "spock"]
 wins_list: list = [
     "scissors,lizard",
@@ -16,13 +17,36 @@ players_table: dict = dict(zip(players_list, wins_list))
 
 
 def player(a_player: str = None) -> list:
+    """ Given a player return the list of players that
+        win in a match against it
+    """
     if not a_player:
         return players_table
     else:
         return sorted(players_table.get(a_player).split(","))
 
 
+def load_players_file() -> list:
+    """ If exists load the file containing a list of players
+        and create a match list. Also perform a sanity check
+        on the list.
+        If the number of players is less than the number of
+        rounds then cycle through the list
+    """
+    # if the file doesn't exist return a list
+    # of empty players
+    if not os.path.isfile(PLAYERS_FILE):
+        return [("", "")] * ROUNDS
+    # read the file, parse it and perform sanity check
+    with open(PLAYERS_FILE) as f:
+        data = f.readlines()
+    return data
+
+
 def match(one: str = "", two: str = "") -> str:
+    """ Given player one and player two return the result
+        of the match (either a tie or one of the two players)
+    """
     # pick a random player if needed
     if one not in players_list:
         one = choice(players_list)
@@ -40,13 +64,17 @@ def match(one: str = "", two: str = "") -> str:
 
 
 def main() -> None:
+    # print some useful information
     print("Rock, paper, scissors, lizard, Spock")
     print(f"Will play {ROUNDS} rounds")
-    counter = 0
-    while counter < ROUNDS:
-        winner = match()
+    # load the players file if it exists
+    # otherwise get a list of empty player
+    # which will trigger the random player selection
+    match_list = load_players_file()
+    # start the game
+    for i in match_list:
+        winner = match(i[0], i[1])
         print(winner)
-        counter += 1
 
 
 if __name__ == "__main__":

--- a/rock-paper-scissors-lizard-spock/rpsls.txt
+++ b/rock-paper-scissors-lizard-spock/rpsls.txt
@@ -1,1 +1,5 @@
+# this file contains a list of players in a very
+# simple format, example:
 rock spock
+this line will be ignored
+lizard rock

--- a/rock-paper-scissors-lizard-spock/rpsls.txt
+++ b/rock-paper-scissors-lizard-spock/rpsls.txt
@@ -1,0 +1,1 @@
+rock spock

--- a/rock-paper-scissors-lizard-spock/test_rpsls.py
+++ b/rock-paper-scissors-lizard-spock/test_rpsls.py
@@ -62,3 +62,11 @@ def test_single_matches(arg1, arg2, expected):
 
 def test_random_single_match():
     assert rpsls.match() in list(test_all_players_data.keys()) + ["tie"]
+
+
+def test_random_single_match_player_one():
+    assert rpsls.match(one="spock") in list(test_all_players_data.keys()) + ["tie"]
+
+
+def test_random_single_match_player_two():
+    assert rpsls.match(two="rock") in list(test_all_players_data.keys()) + ["tie"]

--- a/rock-paper-scissors-lizard-spock/test_rpsls.py
+++ b/rock-paper-scissors-lizard-spock/test_rpsls.py
@@ -25,6 +25,35 @@ test_single_matches_data: list = [
     ("spock", "rock", "spock"),
     ("paper", "lizard", "lizard"),
 ]
+test_e2e_assigned_players_mock_file: list = [
+    "rock scissors",
+    "paper spock",
+    "invalid line",  # invalid
+    "invalidline",  # invalid
+    "another invalid line",  # invalid
+    "lizard rock",
+    "lizard spock",
+    " lizard scissors ",
+    "scissors paper",
+    "scissors paper spock",  # this too is an invalid line
+    "paper paper",
+    "spock rock",
+    "paper lizard",
+    "tie scissors",  # invalid
+    "paper rock",
+]
+test_e2e_assigned_players_data: list = [
+    ("rock"),  # rock beats scissors
+    ("paper"),  # paper beats spock
+    ("rock"),  # rock beats lizard
+    ("lizard"),  # lizard beats spock
+    ("scissors"),  # scissors beat lizard
+    ("scissors"),  # scissors beat paper
+    ("tie"),
+    ("spock"),  # spock beats rock
+    ("lizard"),  # lizard beats paper
+    ("paper"),  # paper beats rock
+]
 
 
 ## test the general behaviour
@@ -90,3 +119,10 @@ def test_e2e_random_players(capsys):
 
 
 # then with assigned players
+def test_e2e_assigned_players(capsys):
+    rpsls.main()
+    captured = capsys.readouterr()
+    captured_lines = captured.out.splitlines()
+    assert f"Will play {ROUNDS} rounds" in captured.out
+    assert len(captured_lines) == 2 + ROUNDS
+    assert all(line in test_all_results_data for line in captured_lines[2:])

--- a/rock-paper-scissors-lizard-spock/test_rpsls.py
+++ b/rock-paper-scissors-lizard-spock/test_rpsls.py
@@ -117,7 +117,8 @@ def test_random_single_match_player_two():
 
 # first with random players
 def test_e2e_random_players(capsys):
-    rpsls.main()
+    with patch("os.path.isfile", return_value=False):
+        rpsls.main()
     captured = capsys.readouterr()
     captured_lines = captured.out.splitlines()
     assert f"Will play {ROUNDS} rounds" in captured.out

--- a/rock-paper-scissors-lizard-spock/test_rpsls.py
+++ b/rock-paper-scissors-lizard-spock/test_rpsls.py
@@ -1,4 +1,5 @@
 import pytest
+from unittest.mock import mock_open, patch
 
 import os
 import rpsls
@@ -43,16 +44,22 @@ test_e2e_assigned_players_mock_file: list = [
     "paper rock",
 ]
 test_e2e_assigned_players_data: list = [
-    ("rock"),  # rock beats scissors
-    ("paper"),  # paper beats spock
-    ("rock"),  # rock beats lizard
-    ("lizard"),  # lizard beats spock
-    ("scissors"),  # scissors beat lizard
-    ("scissors"),  # scissors beat paper
-    ("tie"),
-    ("spock"),  # spock beats rock
-    ("lizard"),  # lizard beats paper
-    ("paper"),  # paper beats rock
+    "rock",  # rock beats scissors
+    "paper",  # paper beats spock
+    "rock",  # rock beats lizard
+    "lizard",  # lizard beats spock
+    "scissors",  # scissors beat lizard
+    "scissors",  # scissors beat paper
+    "tie",
+    "spock",  # spock beats rock
+    "lizard",  # lizard beats paper
+    "paper",  # paper beats rock
+    #
+    "rock",  # repeat the sequence until we reach
+    "paper",  # 15 rounds
+    "rock",
+    "lizard",
+    "scissors",
 ]
 
 
@@ -119,10 +126,13 @@ def test_e2e_random_players(capsys):
 
 
 # then with assigned players
+@patch(
+    "rpsls.open", mock_open(read_data="\n".join(test_e2e_assigned_players_mock_file))
+)
 def test_e2e_assigned_players(capsys):
     rpsls.main()
     captured = capsys.readouterr()
     captured_lines = captured.out.splitlines()
     assert f"Will play {ROUNDS} rounds" in captured.out
     assert len(captured_lines) == 2 + ROUNDS
-    assert all(line in test_all_results_data for line in captured_lines[2:])
+    assert captured_lines[2:] == test_e2e_assigned_players_data

--- a/rock-paper-scissors-lizard-spock/test_rpsls.py
+++ b/rock-paper-scissors-lizard-spock/test_rpsls.py
@@ -11,6 +11,7 @@ test_all_players_data: dict = {
     "lizard": "spock,paper",
     "spock": "scissors,rock",
 }
+test_all_results_data: list = list(test_all_players_data.keys()) + ["tie"]
 test_single_players_data: list = [
     ("rock", ["lizard", "scissors"]),
     ("scissors", ["lizard", "paper"]),
@@ -64,15 +65,15 @@ def test_single_matches(arg1, arg2, expected):
 
 
 def test_random_single_match():
-    assert rpsls.match() in list(test_all_players_data.keys()) + ["tie"]
+    assert rpsls.match() in test_all_results_data
 
 
 def test_random_single_match_player_one():
-    assert rpsls.match(one="spock") in list(test_all_players_data.keys()) + ["tie"]
+    assert rpsls.match(one="spock") in test_all_results_data
 
 
 def test_random_single_match_player_two():
-    assert rpsls.match(two="rock") in list(test_all_players_data.keys()) + ["tie"]
+    assert rpsls.match(two="rock") in test_all_results_data
 
 
 ## test e2e (full cycle of 15 matches)
@@ -82,8 +83,10 @@ def test_random_single_match_player_two():
 def test_e2e_random_players(capsys):
     rpsls.main()
     captured = capsys.readouterr()
+    captured_lines = captured.out.splitlines()
     assert f"Will play {ROUNDS} rounds" in captured.out
-    assert len(captured.out.splitlines()) == 2 + ROUNDS
+    assert len(captured_lines) == 2 + ROUNDS
+    assert all(line in test_all_results_data for line in captured_lines[2:])
 
 
 # then with assigned players

--- a/rock-paper-scissors-lizard-spock/test_rpsls.py
+++ b/rock-paper-scissors-lizard-spock/test_rpsls.py
@@ -1,20 +1,22 @@
 import pytest
 
+import os
 import rpsls
 
-test_all_players_data = {
+ROUNDS: int = int(os.environ.get("RPSLS_ROUNDS", 10))
+test_all_players_data: dict = {
     "rock": "scissors,lizard",
     "paper": "rock,spock",
     "scissors": "paper,lizard",
     "lizard": "spock,paper",
     "spock": "scissors,rock",
 }
-test_single_players_data = [
+test_single_players_data: list = [
     ("rock", ["lizard", "scissors"]),
     ("scissors", ["lizard", "paper"]),
     ("spock", ["rock", "scissors"]),
 ]
-test_single_matches_data = [
+test_single_matches_data: list = [
     ("rock", "rock", "tie"),
     ("scissors", "lizard", "scissors"),
     ("lizard", "scissors", "scissors"),
@@ -28,7 +30,7 @@ test_single_matches_data = [
 def test_output(capsys):
     rpsls.main()
     captured = capsys.readouterr()
-    assert "Will play 15 rounds" in captured.out
+    assert f"Will play {ROUNDS} rounds" in captured.out
 
 
 ## test the data (players, wins)
@@ -36,7 +38,7 @@ def test_all_players():
     assert rpsls.player() == test_all_players_data
 
 
-# replaced by a more general test
+# replaced with a more general test
 # def test_single_player():
 #     assert rpsls.player("spock") == ["rock", "scissors"]
 
@@ -48,7 +50,8 @@ def test_single_players(arg, expected):
 
 
 ## test the results of a match (player vs player)
-# replaced it with a more general test
+
+# replaced with a more general test
 # def test_single_match_win():
 #     assert rpsls.match("scissors", "rock") == "rock"
 # def test_single_match_tie():
@@ -70,3 +73,17 @@ def test_random_single_match_player_one():
 
 def test_random_single_match_player_two():
     assert rpsls.match(two="rock") in list(test_all_players_data.keys()) + ["tie"]
+
+
+## test e2e (full cycle of 15 matches)
+
+
+# first with random players
+def test_e2e_random_players(capsys):
+    rpsls.main()
+    captured = capsys.readouterr()
+    assert f"Will play {ROUNDS} rounds" in captured.out
+    assert len(captured.out.splitlines()) == 2 + ROUNDS
+
+
+# then with assigned players


### PR DESCRIPTION
Added more features (load the list of players from file) and relative testing.
Changes to the documentation to reflect these new features.

From `README.md`:

> A set of players can be assigned in a file `rpsls.txt` which should be located in the same directory. > The format of the file is simple text with two players (one round) on each line, for example:
> ```
> player1 player2
> player1 player2
> ...
> ```
>
> If `number players < number of rounds` the program will cycle through the list and restart from the beginning until the number of rounds is completed. If `number of players > number of rounds` the program will stop once the number of rounds is completed ignoring the rest of the players lines.